### PR TITLE
4. Capa de dominio – Implementación del caso de uso

### DIFF
--- a/app/src/main/java/com/example/cinescan/domain/usecase/AnalyzePosterUseCase.kt
+++ b/app/src/main/java/com/example/cinescan/domain/usecase/AnalyzePosterUseCase.kt
@@ -1,17 +1,29 @@
 package com.example.cinescan.domain.usecase
 
+import com.example.cinescan.data.repository.PosterRepository
 import com.example.cinescan.domain.model.PosterAnalysisResult
+import javax.inject.Inject
 
 /**
  * Caso de uso para analizar pósters de películas y series.
- * De momento, solo la firma y la clase vacía para integrarla más tarde.
  */
-class AnalyzePosterUseCase {
+class AnalyzePosterUseCase @Inject constructor(
+    private val repository: PosterRepository
+) {
     
+    /**
+     * Analiza un póster de película o serie.
+     * 
+     * @param imageBytes Bytes de la imagen del póster
+     * @return Result con el análisis del póster o un error
+     */
     suspend operator fun invoke(imageBytes: ByteArray): Result<PosterAnalysisResult> {
-        // TODO: Implementar la lógica de análisis del póster
-        // Esta implementación se completará en tareas posteriores
-        throw NotImplementedError("El caso de uso aún no está implementado")
+        return try {
+            val result = repository.analyzePoster(imageBytes)
+            Result.success(result)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 }
 

--- a/documentacion/03-tasks.md
+++ b/documentacion/03-tasks.md
@@ -94,11 +94,11 @@
 ## 4. Capa de dominio – Implementación del caso de uso
 
 ### Tarea 4.1: Implementar `AnalyzePosterUseCase`
-- [ ] Inyectar `PosterRepository`.
-- [ ] Implementar:
-  - [ ] Llamada a `repository.analyzePoster(imageBytes)`.
-  - [ ] Envolver el resultado en `Result.success`.
-  - [ ] En caso de excepción, devolver `Result.failure`.
+- [x] Inyectar `PosterRepository`.
+- [x] Implementar:
+  - [x] Llamada a `repository.analyzePoster(imageBytes)`.
+  - [x] Envolver el resultado en `Result.success`.
+  - [x] En caso de excepción, devolver `Result.failure`.
 
 ## 5. Capa de presentación – ViewModel y estado
 


### PR DESCRIPTION
## Resumen
Implementación completa del apartado 4: Capa de dominio – Implementación del caso de uso.

## Tareas Completadas
- [x] Tarea 4.1: Implementar AnalyzePosterUseCase

## Verificación
- ✅ No hay errores de compilación
- ✅ `./gradlew clean build` ejecutado exitosamente
- ✅ Todos los tests relevantes pasan
- ✅ Funcionalidad revisada y aceptada por el usuario

Closes #7